### PR TITLE
Makefile updates: "make help" and more

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,49 @@
-.PHONY: static
+help:
+	@echo "Please use \`$(MAKE) <target>' where <target> is one of the following:"
+	@echo "  setup-git                  optional git config & pre-commit hooks"
+	@echo "  develop                    perform inital development setup"
+	@echo "    install-requirements       install basic deps (npm, bower, python)"
+	@echo "    install-test-requirements  install runtime + testing dependencies"
+	@echo "  upgrade                    perform data migrations"
+	@echo "    install-requirements       (see above)"
+	@echo "    migratedb                  migrate the database schema"
+	@echo "    static                     update static assets (generate css, js)"
+	@echo "  test                       run the unit tests"
+	@echo "    lint                       inspect code for errors"
+	@echo "      lint-js                    run jshint"
+	@echo "      lint-python                run flake8"
+	@echo "  test-full                  run the full test suite and make a coverage report"
+	@echo "    install-test-requirements  (see above)"
+	@echo "    lint                       (see above)"
+	@echo "    coverage                   produce a coverage report"
+	@echo "  resetdb                    drop and re-create the database"
+	@echo "    dropdb                     drop the database"
+	@echo "    createdb                   create an empty database"
+	@echo "    migratedb                  migrate the database schema"
+	@echo ""
+	@echo "For help building documentation, run:"
+	@echo "  $(MAKE) -C docs help"
 
-develop: install-requirements install-test-requirements setup-git
+# Works like "python setup.py develop"
+develop: install-requirements install-test-requirements
 
-upgrade: develop
-	alembic upgrade head
-	make static
+upgrade: install-requirements
+	@# XXX: Can `migratedb' and `static' run in parallel?
+	$(MAKE) migratedb
+	$(MAKE) static
 
 setup-git:
 	git config branch.autosetuprebase always
 	cd .git/hooks && ln -sf ../../hooks/* ./
 
-install-requirements: update-submodules
+install-requirements:
+	@# XXX: Can any of these run in parallel?
 	npm install
 	bower install
 	pip install -e . --use-mirrors --allow-external=argparse
 
-install-test-requirements:
+install-test-requirements: install-requirements
 	pip install "file://`pwd`#egg=changes[tests]" --use-mirrors
-
-update-submodules:
-	git submodule init
-	git submodule update
 
 test: lint
 	@echo "Running Python tests"
@@ -39,14 +62,33 @@ lint-js:
 	@node_modules/.bin/jshint static/
 	@echo ""
 
-test-full: install-requirements install-test-requirements lint
+test-full: install-test-requirements
+	$(MAKE) lint
+	$(MAKE) coverage
+
+coverage:
 	coverage run -m py.test --junitxml=junit.xml tests
 	coverage xml
 
-resetdb:
+dropdb:
 	dropdb --if-exists changes
+
+createdb:
 	createdb -E utf-8 changes
+
+migratedb:
 	alembic upgrade head
+
+resetdb:
+	$(MAKE) dropdb
+	$(MAKE) createdb
+	$(MAKE) migratedb
 
 static:
 	node_modules/.bin/grunt requirejs
+
+# XXX(dlitz): We should have some real build products, too.
+.PHONY: help develop upgrade setup-git \
+	install-requirements install-test-requirements \
+	test lint lint-python lint-js test-full coverage \
+	dropdb createdb migratedb resetdb static


### PR DESCRIPTION
- Add "make help" as the default makefile target.
- Add/rearrange a few makefile dependencies to avoid confusion.
- Split "resetdb" into separate "dropdb", "createdb", "migratedb"
  targets to allow easier automation of "createdb".
- Drop unused "update-submodules".  I don't know how they fit in here,
  and we'll probably do better if we never use submodules in the first
  place.
- Make "setup-git" purely optional, because local pre-commit hooks can
  sometimes be pretty obnoxious:
  
    $ git commit --amend
    sh: 1: node_modules/.bin/jshint: not found
