### PR TITLE
[easy] Delete unused v1/v2 python code

### DIFF
--- a/changes/config.py
+++ b/changes/config.py
@@ -353,10 +353,6 @@ def create_app(_read_config=True, **config):
     # to retry more jobsteps if it's always the same machine failing.
     app.config['JOBSTEP_MACHINE_RETRY_MAX'] = 2
 
-    # we opt these users into the new ui...redirecting them if they
-    # hit the homepage
-    app.config['NEW_UI_OPTIN_USERS'] = set([])
-
     # the PHID of the user creating quarantine tasks. We can use this to show
     # the list of open quarantine tasks inline
     app.config['QUARANTINE_PHID'] = None
@@ -364,8 +360,6 @@ def create_app(_read_config=True, **config):
     # The max length a test's output to be stored. If it is longer, the it will
     # be truncated.
     app.config['TEST_MESSAGE_MAX_LEN'] = 64 * 1024
-
-    app.config['USE_OLD_UI'] = False
 
     # sources.list entry, format is:
     # deb uri distribution [component1] [component2] [...]
@@ -714,19 +708,7 @@ def configure_web_routes(app):
                                                             authorized_url='authorized',
                                                             ))
 
-    if app.config['USE_OLD_UI']:
-        app.add_url_rule(
-            '/static/' + revision + '/<path:filename>',
-            view_func=StaticView.as_view('static', root=static_root))
-        app.add_url_rule(
-            '/partials/<path:filename>',
-            view_func=StaticView.as_view('partials', root=os.path.join(PROJECT_ROOT, 'partials')))
-        app.add_url_rule(
-            '/<path:path>', view_func=IndexView.as_view('index-path'))
-        app.add_url_rule(
-            '/', view_func=IndexView.as_view('index'))
-    else:
-        configure_default(app)
+    configure_default(app)
 
 
 def configure_default(app):
@@ -748,9 +730,8 @@ def configure_default(app):
             hacky_vendor_root=hacky_vendor_root)
     )
 
-    app.add_url_rule('/<path:path>',
-      view_func=IndexView.as_view('index-path', use_v2=True))
-    app.add_url_rule('/', view_func=IndexView.as_view('index', use_v2=True))
+    app.add_url_rule('/<path:path>', view_func=IndexView.as_view('index-path'))
+    app.add_url_rule('/', view_func=IndexView.as_view('index'))
 
     # serve custom images if we have a custom content file
     if app.config['WEBAPP_CUSTOM_JS']:
@@ -761,6 +742,7 @@ def configure_default(app):
                 'custom_image',
                 root=custom_dir)
         )
+
     # One last thing...we use CSS bundling via flask-assets, so set that up on
     # the main app object
     configure_assets(app)

--- a/changes/web/index.py
+++ b/changes/web/index.py
@@ -12,8 +12,7 @@ from changes.models.option import ItemOption
 class IndexView(MethodView):
     custom_js = None
 
-    def __init__(self, use_v2=False):
-        self.use_v2 = use_v2
+    def __init__(self):
         super(MethodView, self).__init__()
 
     def get(self, path=''):
@@ -52,25 +51,17 @@ class IndexView(MethodView):
 
         disable_custom = request.args and "disable_custom" in request.args
 
-        # use new react code
-        if self.use_v2:
-            return render_template('webapp.html', **{
-                'SENTRY_PUBLIC_DSN': dsn,
-                'RELEASE_INFO': changes.get_revision_info(),
-                'WEBAPP_USE_ANOTHER_HOST': use_another_host,
-                'WEBAPP_CUSTOM_JS': (IndexView.custom_js if
-                    not disable_custom else None),
-                'USE_PACKAGED_JS': not current_app.debug,
-                'HAS_CUSTOM_CSS': (current_app.config['WEBAPP_CUSTOM_CSS'] and
-                    not disable_custom),
-                'IS_DEBUG': current_app.debug,
-                'PHABRICATOR_LINK_HOST': current_app.config['PHABRICATOR_LINK_HOST'],
-                'COLORBLIND': (user_options.get('user.colorblind') and
-                    user_options.get('user.colorblind') != '0'),
-            })
-
-        return render_template('index.html', **{
+        return render_template('webapp.html', **{
             'SENTRY_PUBLIC_DSN': dsn,
-            'VERSION': changes.get_version(),
-            'WEBAPP_USE_ANOTHER_HOST': use_another_host
+            'RELEASE_INFO': changes.get_revision_info(),
+            'WEBAPP_USE_ANOTHER_HOST': use_another_host,
+            'WEBAPP_CUSTOM_JS': (IndexView.custom_js if
+                not disable_custom else None),
+            'USE_PACKAGED_JS': not current_app.debug,
+            'HAS_CUSTOM_CSS': (current_app.config['WEBAPP_CUSTOM_CSS'] and
+                not disable_custom),
+            'IS_DEBUG': current_app.debug,
+            'PHABRICATOR_LINK_HOST': current_app.config['PHABRICATOR_LINK_HOST'],
+            'COLORBLIND': (user_options.get('user.colorblind') and
+                user_options.get('user.colorblind') != '0'),
         })


### PR DESCRIPTION
Now that the old UI is completely unused, delete references to it in the
python codebase

Test Plan: git grep v2, git grep NEW_UI_OPTIN_USERS, git grep
USE_OLD_UI, sanity checked hitting homepage